### PR TITLE
fix hidden post settings

### DIFF
--- a/revert.user.js
+++ b/revert.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Piazza Revert
 // @namespace    https://github.com/embeddedt
-// @version      0.2
+// @version      0.3
 // @description  Revert Piazza to the old user interface
 // @author       embeddedt
 // @match        https://piazza.com/*
@@ -273,7 +273,6 @@
             border-bottom-left-radius: 0;
             border-bottom-right-radius: 0;
             box-shadow: 0 1px 4px rgba(0,0,0,.15);
-            clip-path: inset(-4px -4px 0px -4px);
             border: 1px solid var(--qa-section-border-color);
             padding: 0.5rem 1rem !important;
             margin: 0 0.5rem;


### PR DESCRIPTION
Before the change,  the dropdown menu with extra options per page gets obscured:

<img width="1920" height="904" alt="image" src="https://github.com/user-attachments/assets/ef4d127e-2046-48d4-bb38-d05b1c7f2868" />

After the change, it looks good:

<img width="1914" height="911" alt="image" src="https://github.com/user-attachments/assets/47aec26f-0cfe-4b7e-8c67-56291110f9f0" />

Not sure what this was originally added for, so I don't know if this fix breaks something else.