### PR TITLE
use user settings for hover preview delay

### DIFF
--- a/src/userscript.js
+++ b/src/userscript.js
@@ -259,7 +259,7 @@ function injectImageHover() {
                     previewEl = null;
                 }
             }, { once: true });
-        }, 400); // delay in ms
+        }, userscriptSettings.get("hoverPreviewDelay")); // delay in ms
     });
 
     document.addEventListener("mouseout", e => {


### PR DESCRIPTION
note that when users change the hover preview setting, they will have to refresh the page for it to take effect